### PR TITLE
feat: add Github Action CI to run test on Pull Request #10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - run: yarn
-      - run: yarn next build
+          cache: 'npm'
+      - run: npm i --force
+      - run: npm run build
       - run: rm -rf .next

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Pull Request Test
+run-name: ${{ github.actor }} is testing a Pull Request
+on:
+  push:
+    pull_request:
+      branches:
+        - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    matrix:
+      node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn next build
+      - run: rm -rf .next

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    matrix:
-      node-version: [16]
+    strategy:
+      matrix:
+        node-version: [16]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     matrix:
-      node-version: [16.x]
+      node-version: [16]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
closes #10 

changes:
- add a Github Action CI yaml to run `yarn build` when a new commit is pushed over a Pull Request, example: [https://github.com/ridhof/next-landing-vpn/pull/1](https://github.com/ridhof/next-landing-vpn/pull/1)

some things should be noted:
- we have to be clear, are we going to use `yarn` or `npm`. because currently we have both `package-lock.json` that was generated by `npm`, and `yarn.lock` that was generated by `yarn`.
- after deciding which one we going to use, we have to remove the unused lock file. I think it can be a new different issue for hacktoberfest to delete the lock file
- currently, I am using `yarn` for CI
- when using `npm i`, I couldn't install the packages. Is this expected?
- I got an error when running `yarn next export`, is this expected?

